### PR TITLE
Исправление задания A07 restore_password.

### DIFF
--- a/EGE/Gen/A07.pm
+++ b/EGE/Gen/A07.pm
@@ -205,14 +205,13 @@ sub restore_password {
     my $ans = shift @{$good_variants};
 
     @{$self->{variants}} = (
-       $ans->[0],
        @{$bad_variants},
        (map {$_->[0]} @{$good_variants}),
        @{$bad_variants3},
        (map {$_->[0]} @{$bad_variants2})
    );
 
-    @{$self->{variants}} = rnd->pick_n(4, @{$self->{variants}});
+    @{$self->{variants}} = ($ans->[0], rnd->pick_n(3, @{$self->{variants}}));
 
     my $OS = rnd->pick("Windows XP", "GNU/Linux", "почтовый аккаунт");
     $self->{text} .=


### PR DESCRIPTION
Проблема: зачастую отсутствует верный вариант в списке ответов.
Причина: при выборе ответом из имеющихся хороший ответ перемешивался с
плохими.
