### PR TITLE
Исправил установку флага PF для ?h регистров

### DIFF
--- a/EGE/Asm/Register.pm
+++ b/EGE/Asm/Register.pm
@@ -50,7 +50,7 @@ sub set_ZSPF {
     my ($self, $eflags) = @_;
     $eflags->{ZF} = $self->get_value() ? 0 : 1;
     $eflags->{SF} = $self->{bits}->{v}[$self->{id_from}];
-    $eflags->{PF} = 1 - scalar(grep $self->{bits}->{v}[$_], 24 .. 31) % 2;
+    $eflags->{PF} = 1 - scalar(grep $self->{bits}->{v}[$_], $self->{id_to} - 8 .. $self->{id_to} - 1) % 2;
     $self;
 }
 

--- a/t/processor.t
+++ b/t/processor.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 193;
+use Test::More tests => 195;
 use Test::Exception;
 
 use lib '..';
@@ -55,6 +55,10 @@ sub check_stack {
     proc->run_code([ ['mov', 'ah', 15], ['add', 'ah', 7] ]);
     is proc->get_val('eax'), 22 * 256, 'add to ah';
     is proc->{eflags}->flags_text, '', 'add to ah set flags';
+
+    proc->run_code([ ['mov', 'ah', 16], ['add', 'ah', 7] ]);
+    is proc->get_val('eax'), 23 * 256, 'add to ah (2)';
+    is proc->{eflags}->flags_text, 'PF', 'add to ah set flags (2)';
 
     proc->run_code([ ['mov', 'al', 15], ['add', 'al', -7] ]);
     is proc->get_val('eax'), 8, 'add negative less number';

--- a/t/processor.t
+++ b/t/processor.t
@@ -54,7 +54,7 @@ sub check_stack {
 
     proc->run_code([ ['mov', 'ah', 15], ['add', 'ah', 7] ]);
     is proc->get_val('eax'), 22 * 256, 'add to ah';
-    is proc->{eflags}->flags_text, 'PF', 'add to ah set flags';
+    is proc->{eflags}->flags_text, '', 'add to ah set flags';
 
     proc->run_code([ ['mov', 'al', 15], ['add', 'al', -7] ]);
     is proc->get_val('eax'), 8, 'add negative less number';


### PR DESCRIPTION
Раньше при работе с регистрами ?h, проверялся первый байт регистра e?x, что приводило к неверным результатам.