### PR TITLE
Arch07 Убрать отдельную обработку регистров ?h при jp и jnp

### DIFF
--- a/EGE/Gen/Arch/Arch07.pm
+++ b/EGE/Gen/Arch/Arch07.pm
@@ -33,14 +33,9 @@ sub loop_number {
     my $inf = 'бесконечное число (программа зациклится)';
     if ($jmp eq 'jp' || $jmp eq 'jnp') {
         $self->variants(1, 2, 3, $inf);
-        if ($reg =~ m/^[a-d]h$/) {
-            $self->{correct} = $jmp eq 'jp' ? 3 : 0;
-        }
-        else {
-            cgen->add_command('add', $reg2, 1);
-            cgen->move_command(4, 2);
-            $self->{correct} = proc->run_code(cgen->{code})->get_val($reg2) - 1;
-        }
+        cgen->add_command('add', $reg2, 1);
+        cgen->move_command(4, 2);
+        $self->{correct} = proc->run_code(cgen->{code})->get_val($reg2) - 1;
     }
     elsif ($jmp eq 'jo') {
         $self->variants(1, 256 - $arg, (128 - $arg + 256) % 256, $inf);


### PR DESCRIPTION
Исправление https://github.com/klenin/EGE/issues/81
![default](https://cloud.githubusercontent.com/assets/11499132/21500535/7b1669ec-cc8b-11e6-9416-9006e6ee8a10.png)


Раньше при выполнении команд jp и jnp с регистрами ?h ответ мог быть только 1 или бесконечность.
Теперь эти регистры обрабатываются вместе со всеми остальными.
