### PR TITLE
Исправлен баг в отображении условия EGE/B06 recursive function

### DIFF
--- a/EGE/Gen/EGE/B06.pm
+++ b/EGE/Gen/EGE/B06.pm
@@ -317,7 +317,7 @@ sub recursive_function {
         ],
         [ '()', 'F', 'n' ],
         [ '>=', 'n', 2 ],
-        [ '()', 'F', 'n' ],
+        [ '()', 'F', $n ],
     );
 
     my @texts = map EGE::Prog::make_expr($_)->to_lang_named('Logic', { html => 1 }), @exprs;


### PR DESCRIPTION
При выводе условия задачи вместо подстановки действующего
значения n (например, F(5)) выводилось просто n (например, F(n))