### PR TITLE
Добавлена задача EGE/B03 last-digit-base

### DIFF
--- a/EGE/Gen/EGE/B03.pm
+++ b/EGE/Gen/EGE/B03.pm
@@ -41,6 +41,21 @@ sub last_digit {
     $self->{accept} = qr/^(?:\d+,)+(\d+)$/;
 }
 
+sub last_digit_base {
+    my ($self) = @_;
+    my ($number, $rem, @bases);
+    do {
+        $number = rnd->in_range(10, 60);
+        $rem = rnd->in_range(1, 9);
+        @bases = grep { $number % $_ == $rem } 2..$number;
+    } while (@bases < 2);
+    $self->{text} = 
+        'Укажите в порядке возрастания через запятую без пробелов все основания систем счисления, ' .
+        "в которых запись числа $number оканчивается на $rem.";
+    $self->{correct} = join ',', @bases;
+    $self->{accept} = qr/^(?:\d+,)+(\d+)$/;
+}
+
 sub count_digits {
     my ($self) = @_;
     my ($num, $base);

--- a/EGE/Generate.pm
+++ b/EGE/Generate.pm
@@ -105,7 +105,7 @@ sub all {[
     gg('B01', qw(direct recode2)),
     gg('B02', qw(flowchart)),
     gg('B02', qw(simple_while)),
-    gg('B03', qw(q1234 last_digit count_digits count_ones music_time_to_time music_size_to_size music_format_time_to_time select_base move_number)),
+    gg('B03', qw(q1234 last_digit last_digit_base count_digits count_ones music_time_to_time music_size_to_size music_format_time_to_time select_base move_number)),
     gg('B03', qw(simple_equation)),
     gg('B04', qw(impl_border lex_order morse bulbs plus_minus)),
     gg('B05', qw(calculator complete_spreadsheet)),

--- a/gen.pl
+++ b/gen.pl
@@ -204,6 +204,7 @@ binmode STDOUT, ':utf8';
 #g('B02', 'simple_while');
 #g('B03', 'q1234');
 #g('B03', 'last_digit');
+#g('B03', 'last_digit_base');
 #g('B03', 'count_digits');
 #g('B03', 'simple_equation');
 #g('B03', 'count_ones');


### PR DESCRIPTION
Задача является обратной к задаче last-digit, т.е.
вместо самих чисел, нужно определить СС в которых
число оканчивается на заданную цифру.

За основу задачи взята задача E89DEE из банка заданий ЕГЭ fipi.ru