### PR TITLE
Добавлено задание Z18: Поразрядная конъюнкция

### DIFF
--- a/EGE/Gen/EGE/Z18.pm
+++ b/EGE/Gen/EGE/Z18.pm
@@ -1,5 +1,4 @@
-# Copyright © 2010-2012 Alexander S. Klenin
-# Copyright © 2012 V. Kevroletin
+# Copyright © 2010-2017 Alexander S. Klenin
 # Licensed under GPL version 2 or later.
 # http://github.com/klenin/EGE
 package EGE::Gen::EGE::Z18;
@@ -15,15 +14,18 @@ sub bitwise_conjunction {
     my ($self) = @_;
     my $p1 = rnd->in_range(1, 255);
     my $p2 = rnd->in_range_except(1, 255, $p1);
-    $self->{correct} = $p1 & $p2 ^ $p1;
+    my $ans = $p1 & $p2 ^ $p1;
+    $self->{correct} = $ans;
+    my $x = rnd->in_range(1, 255);
+    die 'Z18: Wrong Genereted Answer' unless ($x & $p1) == 0 || ($x & $p2) != 0 || ($x & $ans) != 0;
     $self->accept_number();
     $self->{text} = <<QUESTION
-        Обозначим через m&amp;n поразрядную конъюнкцию неотрицательных целых
-        чисел m и n. Так, например, 14&amp;5 = 1110<sub>2</sub>&amp;0101<sub>2</sub> = 0100<sub>2</sub> = 4.
-        Для какого наименьшего неотрицательного целого числа А формула
-        <p>x&amp;$p1 = 0 \/ (x&amp;$p2 = 0 → x&amp;А ≠ 0)</p>
+        Обозначим через <i>m</i>&amp;<i>n</i> поразрядную конъюнкцию неотрицательных целых
+        чисел <i>m</i> и <i>n</i>. Так, например, 14&amp;5 = 1110<sub>2</sub>&amp;0101<sub>2</sub> = 0100<sub>2</sub> = 4.
+        Для какого наименьшего неотрицательного целого числа <i>А</i> формула
+        <blockquote><i>x</i>&amp;$p1 = 0 ∨ (<i>x</i>&amp;$p2 = 0 → <i>x</i>&amp;<i>А</i> ≠ 0)</blockquote>
         тождественно истинна (т.е. принимает значение 1 при любом
-        неотрицательном целом значении переменной х)?
+        неотрицательном целом значении переменной <i>х</i>)?
 QUESTION
 }
 

--- a/EGE/Gen/EGE/Z18.pm
+++ b/EGE/Gen/EGE/Z18.pm
@@ -1,0 +1,30 @@
+# Copyright © 2010-2012 Alexander S. Klenin
+# Copyright © 2012 V. Kevroletin
+# Licensed under GPL version 2 or later.
+# http://github.com/klenin/EGE
+package EGE::Gen::EGE::Z18;
+use base 'EGE::GenBase::DirectInput';
+
+use strict;
+use warnings;
+use utf8;
+
+use EGE::Random;
+
+sub bitwise_conjunction {
+    my ($self) = @_;
+    my $p1 = rnd->in_range(1, 255);
+    my $p2 = rnd->in_range_except(1, 255, $p1);
+    $self->{correct} = $p1 & $p2 ^ $p1;
+    $self->accept_number();
+    $self->{text} = <<QUESTION
+        Обозначим через m&amp;n поразрядную конъюнкцию неотрицательных целых
+        чисел m и n. Так, например, 14&amp;5 = 1110<sub>2</sub>&amp;0101<sub>2</sub> = 0100<sub>2</sub> = 4.
+        Для какого наименьшего неотрицательного целого числа А формула
+        <p>x&amp;$p1 = 0 \/ (x&amp;$p2 = 0 → x&amp;А ≠ 0)</p>
+        тождественно истинна (т.е. принимает значение 1 при любом
+        неотрицательном целом значении переменной х)?
+QUESTION
+}
+
+1;

--- a/EGE/Generate.pm
+++ b/EGE/Generate.pm
@@ -68,6 +68,7 @@ use EGE::Gen::EGE::Z11;
 use EGE::Gen::EGE::Z13;
 use EGE::Gen::EGE::Z15;
 use EGE::Gen::EGE::Z16;
+use EGE::Gen::EGE::Z18;
 use EGE::Gen::EGE::Z22;
 
 sub g {
@@ -126,6 +127,7 @@ sub all {[
     gg('Z13', qw(tumblers tumblers_min)),
     gg('Z15', qw(city_roads)),
     gg('Z16', qw(base_gcd)),
+    gg('Z18', qw(bitwise_conjunction)),
     gg('Z22', qw(calculator_find_prgm_count)),
 ]}
 

--- a/gen.pl
+++ b/gen.pl
@@ -257,6 +257,7 @@ binmode STDOUT, ':utf8';
 #g('Z13', 'tumblers_min');
 #g('Z15', 'city_roads');
 #g('Z16', 'base_gcd');
+#g('Z18', 'bitwise_conjunction');
 #g('Z22', 'calculator_find_prgm_count');
 #g1('Arch01', 'reg_value_add');
 #g1('Arch01', 'reg_value_logic');


### PR DESCRIPTION
Демонстрационный вариант
контрольных измерительных материалов единого
государственного экзамена 2017 года
по информатике и ИКТ

Обозначим через m&n поразрядную конъюнкцию неотрицательных целых
чисел m и n. Так, например, 14&5 = 11102&01012 = 01002 = 4.
Для какого наименьшего неотрицательного целого числа А формула
x&51 = 0 \/ (x&41 = 0 → x&А ≠ 0)
тождественно истинна (т.е. принимает значение 1 при любом
неотрицательном целом значении переменной х)?

http://fipi.ru/ege-i-gve-11/demoversii-specifikacii-kodifikatory